### PR TITLE
improve readability of macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - stable
+  - nightly
 
 before_script: |
   rustup component add rustfmt-preview &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,15 @@ rust:
   - nightly
 
 before_script: |
-  rustup component add rustfmt-preview;
   rustup component add clippy-preview;
+  if ! rustup component add clippy; then
+    target=`curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/clippy`;
+    echo "'clippy' is unavailable on the toolchain 'nightly', using the toolchain 'nightly-$target' instead";
+    rustup toolchain install nightly-$target;
+    rustup default nightly-$target;
+    rustup component add clippy;
+  fi
+  rustup component add rustfmt-preview;
   if ! rustup component add rustfmt; then
     target=`curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/rustfmt`;
     echo "'rustfmt' is unavailable on the toolchain 'nightly', use the toolchain 'nightly-$target' instead";

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,15 @@ rust:
   - nightly
 
 before_script: |
-  rustup component add rustfmt-preview &&
-  rustup component add clippy-preview
+  rustup component add rustfmt-preview;
+  rustup component add clippy-preview;
+  if ! rustup component add rustfmt; then
+    target=`curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/rustfmt`;
+    echo "'rustfmt' is unavailable on the toolchain 'nightly', use the toolchain 'nightly-$target' instead";
+    rustup toolchain install nightly-$target;
+    rustup default nightly-$target;
+    rustup component add rustfmt;
+  fi
 script: |
   cargo fmt -- --check &&
   cargo clippy -- -D clippy &&

--- a/src/join.rs
+++ b/src/join.rs
@@ -28,7 +28,7 @@ macro_rules! join {
             $(
                 // Move future into a local so that it is pinned in one place and
                 // is no longer accessible by the end user.
-                let mut $fut = $crate::maybe_done($fut);
+                let mut $fut = $crate::MaybeDone::new($fut);
             )*
             $crate::utils::poll_fn(move |cx| {
                 use $crate::utils::future::Future;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ mod select;
 mod try_join;
 mod try_select;
 
-pub use maybe_done::{maybe_done, MaybeDone};
+pub use maybe_done::MaybeDone;
 
 /// Helper re-exports for use in macros.
 pub mod utils {

--- a/src/maybe_done.rs
+++ b/src/maybe_done.rs
@@ -28,33 +28,33 @@ impl<Fut: Future> MaybeDone<Fut> {
         Self::Future(future)
     }
 
-    /// Returns an [`Option`] containing a mutable reference to the output of the future.
-    /// The output of this method will be [`Some`] if and only if the inner
-    /// future has been completed and [`take`](MaybeDone::take)
-    /// has not yet been called.
-    #[allow(clippy::wrong_self_convention)]
-    #[inline]
-    pub fn as_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
-        unsafe {
-            let this = self.get_unchecked_mut();
-            match this {
-                MaybeDone::Done(res) => Some(res),
-                _ => None,
-            }
-        }
-    }
-
     /// Returns an [`Option`] containing a reference to the output of the future.
     /// The output of this method will be [`Some`] if and only if the inner
     /// future has been completed and [`take`](MaybeDone::take)
     /// has not yet been called.
     #[allow(clippy::wrong_self_convention)]
     #[inline]
-    pub fn as_ref(self: Pin<&Self>) -> Option<&Fut::Output> {
+    pub fn output(self: Pin<&Self>) -> Option<&Fut::Output> {
         let this = self.get_ref();
         match this {
             MaybeDone::Done(res) => Some(res),
             _ => None,
+        }
+    }
+
+    /// Returns an [`Option`] containing a mutable reference to the output of the future.
+    /// The output of this method will be [`Some`] if and only if the inner
+    /// future has been completed and [`take`](MaybeDone::take)
+    /// has not yet been called.
+    #[allow(clippy::wrong_self_convention)]
+    #[inline]
+    pub fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            match this {
+                MaybeDone::Done(res) => Some(res),
+                _ => None,
+            }
         }
     }
 
@@ -75,6 +75,8 @@ impl<Fut: Future> MaybeDone<Fut> {
             }
         }
     }
+
+    // fn ok(self) -> Option<Fut::Output> {}
 }
 
 impl<Fut: Future> Future for MaybeDone<Fut> {

--- a/src/maybe_done.rs
+++ b/src/maybe_done.rs
@@ -10,11 +10,6 @@ use core::pin::Pin;
 use futures_core::ready;
 use futures_core::task::{Context, Poll};
 
-/// Create a new instance of `MaybeDone`.
-pub fn maybe_done<Fut: Future>(future: Fut) -> MaybeDone<Fut> {
-    MaybeDone::Future(future)
-}
-
 /// A future that may have completed.
 #[derive(Debug)]
 pub enum MaybeDone<Fut: Future> {
@@ -28,10 +23,16 @@ pub enum MaybeDone<Fut: Future> {
 }
 
 impl<Fut: Future> MaybeDone<Fut> {
+    /// Create a new instance of `MaybeDone`.
+    pub fn new(future: Fut) -> MaybeDone<Fut> {
+        Self::Future(future)
+    }
+
     /// Returns an [`Option`] containing a mutable reference to the output of the future.
     /// The output of this method will be [`Some`] if and only if the inner
     /// future has been completed and [`take`](MaybeDone::take)
     /// has not yet been called.
+    #[allow(clippy::wrong_self_convention)]
     #[inline]
     pub fn as_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
         unsafe {
@@ -47,6 +48,7 @@ impl<Fut: Future> MaybeDone<Fut> {
     /// The output of this method will be [`Some`] if and only if the inner
     /// future has been completed and [`take`](MaybeDone::take)
     /// has not yet been called.
+    #[allow(clippy::wrong_self_convention)]
     #[inline]
     pub fn as_ref(self: Pin<&Self>) -> Option<&Fut::Output> {
         let this = self.get_ref();

--- a/src/maybe_done.rs
+++ b/src/maybe_done.rs
@@ -45,7 +45,6 @@ impl<Fut: Future> MaybeDone<Fut> {
     /// The output of this method will be [`Some`] if and only if the inner
     /// future has been completed and [`take`](MaybeDone::take)
     /// has not yet been called.
-    #[allow(clippy::wrong_self_convention)]
     #[inline]
     pub fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
         unsafe {

--- a/src/maybe_done.rs
+++ b/src/maybe_done.rs
@@ -32,7 +32,6 @@ impl<Fut: Future> MaybeDone<Fut> {
     /// The output of this method will be [`Some`] if and only if the inner
     /// future has been completed and [`take`](MaybeDone::take)
     /// has not yet been called.
-    #[allow(clippy::wrong_self_convention)]
     #[inline]
     pub fn output(self: Pin<&Self>) -> Option<&Fut::Output> {
         let this = self.get_ref();

--- a/src/select.rs
+++ b/src/select.rs
@@ -46,7 +46,7 @@ macro_rules! select {
                     let fut = unsafe { Pin::new_unchecked(&mut $fut) };
                     if Future::poll(fut, cx).is_ready() {
                         let fut = unsafe { Pin::new_unchecked(&mut $fut) };
-                        let output = fut.take_output().unwrap();
+                        let output = fut.take().unwrap();
                         return Poll::Ready(output);
                     }
                 )*

--- a/src/select.rs
+++ b/src/select.rs
@@ -35,7 +35,7 @@ macro_rules! select {
             $(
                 // Move future into a local so that it is pinned in one place and
                 // is no longer accessible by the end user.
-                let mut $fut = $crate::maybe_done($fut);
+                let mut $fut = $crate::MaybeDone::new($fut);
             )*
             $crate::utils::poll_fn(move |cx| {
                 use $crate::utils::future::Future;

--- a/src/try_join.rs
+++ b/src/try_join.rs
@@ -61,7 +61,7 @@ macro_rules! try_join {
                     let fut = unsafe { Pin::new_unchecked(&mut $fut) };
                     if Future::poll(fut, cx).is_pending() {
                         all_done = false;
-                    } else if unsafe { Pin::new_unchecked(&mut $fut) }.as_mut().unwrap().is_err() {
+                    } else if unsafe { Pin::new_unchecked(&mut $fut) }.output_mut().unwrap().is_err() {
                         // `.err().unwrap()` rather than `.unwrap_err()` so that we don't introduce
                         // a `T: Debug` bound.
                         return Poll::Ready(

--- a/src/try_join.rs
+++ b/src/try_join.rs
@@ -52,7 +52,7 @@ macro_rules! try_join {
             $(
                 // Move future into a local so that it is pinned in one place and
                 // is no longer accessible by the end user.
-                let mut $fut = $crate::maybe_done($fut);
+                let mut $fut = $crate::MaybeDone::new($fut);
             )*
 
             let res: Result<_, _> = poll_fn(move |cx| {

--- a/src/try_select.rs
+++ b/src/try_select.rs
@@ -52,7 +52,7 @@ macro_rules! try_select {
                     let fut = unsafe { Pin::new_unchecked(&mut $fut) };
                     if Future::poll(fut, cx).is_ready() {
                         let fut = Pin::new(&$fut);
-                        if fut.as_ref().unwrap().is_ok() {
+                        if fut.output().unwrap().is_ok() {
                             let fut = unsafe { Pin::new_unchecked(&mut $fut) };
                             let res = fut.take().unwrap();
                             return Poll::Ready(res);

--- a/src/try_select.rs
+++ b/src/try_select.rs
@@ -6,7 +6,7 @@
 ///
 /// `try_select!` is similar to [`select!`], but keeps going if a future
 /// resolved to an error until all futures have been resolved. In which case
-/// the last error found will be returned.
+/// the error of the last item in the list will be returned.
 ///
 /// This macro is only usable inside of async functions, closures, and blocks.
 ///
@@ -42,7 +42,7 @@ macro_rules! try_select {
             $(
                 // Move future into a local so that it is pinned in one place and
                 // is no longer accessible by the end user.
-                let mut $fut = $crate::maybe_done($fut);
+                let mut $fut = $crate::MaybeDone::new($fut);
             )*
 
             let res: Result<_, _> = poll_fn(move |cx| {

--- a/src/try_select.rs
+++ b/src/try_select.rs
@@ -19,7 +19,7 @@
 /// use futures::future;
 /// use std::io::{Error, ErrorKind};
 ///
-/// let a = future::pending::<Result<u8, Error>>();
+/// let a = future::pending::<Result<_, Error>>();
 /// let b = future::ready(Err(Error::from(ErrorKind::Other)));
 /// let c = future::ready(Ok(1u8));
 ///
@@ -33,26 +33,29 @@
 macro_rules! try_select {
     ($($fut:ident),+ $(,)?) => { {
         async {
+            use $crate::utils::future::Future;
+            use $crate::utils::pin::Pin;
+            use $crate::utils::poll_fn;
+            use $crate::utils::result::Result;
+            use $crate::utils::task::Poll;
+
             $(
                 // Move future into a local so that it is pinned in one place and
                 // is no longer accessible by the end user.
                 let mut $fut = $crate::maybe_done($fut);
             )*
-            $crate::utils::poll_fn(move |cx| {
-                use $crate::utils::future::Future;
-                use $crate::utils::task::Poll;
-                use $crate::utils::pin::Pin;
 
+            let res: Result<_, _> = poll_fn(move |cx| {
                 let mut all_done = true;
 
                 $(
                     let fut = unsafe { Pin::new_unchecked(&mut $fut) };
                     if Future::poll(fut, cx).is_ready() {
                         let fut = Pin::new(&$fut);
-                        if fut.output().unwrap().is_ok() {
+                        if fut.as_ref().unwrap().is_ok() {
                             let fut = unsafe { Pin::new_unchecked(&mut $fut) };
-                            let output = fut.take_output().unwrap();
-                            return Poll::Ready(output);
+                            let res = fut.take().unwrap();
+                            return Poll::Ready(res);
                         } else {
                             all_done = false;
                         }
@@ -62,20 +65,20 @@ macro_rules! try_select {
                 )*
 
                 if all_done {
-                    // We need to iterate over all items to not get an
-                    // "unreachable code" warning.
+                    // We need to iterate over all items to get the last error.
                     let mut err = None;
                     $(
                         if err.is_none() {
                             let fut = unsafe { Pin::new_unchecked(&mut $fut) };
-                            err = Some(fut.take_output().unwrap());
+                            err = Some(fut.take().unwrap());
                         }
                     )*
                     return Poll::Ready(err.unwrap());
                 } else {
                     Poll::Pending
                 }
-            }).await
+            }).await;
+            res
         }
     } }
 }


### PR DESCRIPTION
Cleaned the macros up, and made them more understandable overall. Also changed the method names of `MaybeDone` to make them similar to std. Thanks!