### PR TITLE
Join stream

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -10,6 +10,11 @@ fn main() {
             let c = future::ready(Ok(1u8));
 
             assert_eq!(try_select!(a, b, c).await?, 1u8);
+
+            use async_macros::JoinStream;
+            use futures::stream::{self, StreamExt};
+            use futures::future::ready;
+
             Ok(())
         }
         main().await.unwrap();

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -10,11 +10,6 @@ fn main() {
             let c = future::ready(Ok(1u8));
 
             assert_eq!(try_select!(a, b, c).await?, 1u8);
-
-            use async_macros::JoinStream;
-            use futures::stream::{self, StreamExt};
-            use futures::future::ready;
-
             Ok(())
         }
         main().await.unwrap();

--- a/src/join_stream.rs
+++ b/src/join_stream.rs
@@ -1,0 +1,36 @@
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::Stream;
+
+/// A stream joining two or more streams.
+///
+/// This stream is returned by `join!`.
+#[derive(Debug)]
+pub struct JoinStream<'a, L, R, T> {
+    left: &'a mut L,
+    right: &'a mut R,
+    _marker: PhantomData<T>,
+}
+
+impl<L, R, T> Unpin for JoinStream<'_, L, R, T> {}
+
+impl<'a, L, R, T> Stream for JoinStream<'a, L, R, T>
+where
+    L: Stream<Item = T> + Unpin,
+    R: Stream<Item = T> + Unpin,
+{
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Poll::Ready(Some(item)) = Pin::new(&mut *self.left).poll_next(cx) {
+            // The first stream made progress. The JoinStream needs to be polled
+            // again to check the progress of the second stream.
+            cx.waker().wake_by_ref();
+            Poll::Ready(Some(item))
+        } else {
+            Pin::new(&mut *self.right).poll_next(cx)
+        }
+    }
+}

--- a/src/join_stream.rs
+++ b/src/join_stream.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -8,26 +7,21 @@ use futures_core::Stream;
 ///
 /// This stream is returned by `join!`.
 #[derive(Debug)]
-pub struct JoinStream<L, R, T> {
+pub struct JoinStream<L, R> {
     left: L,
     right: R,
-    _marker: PhantomData<T>,
 }
 
-impl<L, R, T> Unpin for JoinStream<L, R, T> {}
+impl<L, R> Unpin for JoinStream<L, R> {}
 
-impl<L, R, T> JoinStream<L, R, T> {
+impl<L, R> JoinStream<L, R> {
     #[doc(hidden)]
     pub fn new(left: L, right: R) -> Self {
-        Self {
-            left,
-            right,
-            _marker: PhantomData,
-        }
+        Self { left, right }
     }
 }
 
-impl<L, R, T> Stream for JoinStream<L, R, T>
+impl<L, R, T> Stream for JoinStream<L, R>
 where
     L: Stream<Item = T> + Unpin,
     R: Stream<Item = T> + Unpin,

--- a/src/join_stream.rs
+++ b/src/join_stream.rs
@@ -8,15 +8,26 @@ use futures_core::Stream;
 ///
 /// This stream is returned by `join!`.
 #[derive(Debug)]
-pub struct JoinStream<'a, L, R, T> {
-    left: &'a mut L,
-    right: &'a mut R,
+pub struct JoinStream<L, R, T> {
+    left: L,
+    right: R,
     _marker: PhantomData<T>,
 }
 
-impl<L, R, T> Unpin for JoinStream<'_, L, R, T> {}
+impl<L, R, T> Unpin for JoinStream<L, R, T> {}
 
-impl<'a, L, R, T> Stream for JoinStream<'a, L, R, T>
+impl<L, R, T> JoinStream<L, R, T> {
+    #[doc(hidden)]
+    pub fn new(left: L, right: R) -> Self {
+        Self {
+            left,
+            right,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<L, R, T> Stream for JoinStream<L, R, T>
 where
     L: Stream<Item = T> + Unpin,
     R: Stream<Item = T> + Unpin,
@@ -24,13 +35,48 @@ where
     type Item = T;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if let Poll::Ready(Some(item)) = Pin::new(&mut *self.left).poll_next(cx) {
+        if let Poll::Ready(Some(item)) = Pin::new(&mut self.left).poll_next(cx) {
             // The first stream made progress. The JoinStream needs to be polled
             // again to check the progress of the second stream.
             cx.waker().wake_by_ref();
             Poll::Ready(Some(item))
         } else {
-            Pin::new(&mut *self.right).poll_next(cx)
+            Pin::new(&mut self.right).poll_next(cx)
         }
     }
+}
+
+/// Combines multiple streams into a single stream of all their outputs.
+///
+/// This macro is only usable inside of async functions, closures, and blocks.
+///
+/// # Examples
+///
+/// ```
+/// # futures::executor::block_on(async {
+/// use async_macros::join_stream as join;
+/// use futures::stream::{self, StreamExt};
+/// use futures::future::ready;
+///
+/// let a = &mut stream::once(ready(1u8));
+/// let b = &mut stream::once(ready(2u8));
+/// let c = &mut stream::once(ready(3u8));
+///
+/// let mut s = join!(a, b, c);
+///
+/// assert_eq!(s.next().await, Some(1u8));
+/// assert_eq!(s.next().await, Some(2u8));
+/// assert_eq!(s.next().await, Some(3u8));
+/// assert_eq!(s.next().await, None);
+/// # });
+/// ```
+#[macro_export]
+macro_rules! join_stream {
+    ($stream1:ident, $stream2:ident, $($stream:ident),* $(,)?) => {{
+        let joined = $crate::JoinStream::new($stream1, $stream2);
+        $(
+            let joined = $crate::JoinStream::new(joined, $stream);
+        )*
+        joined
+    }};
 }

--- a/src/join_stream.rs
+++ b/src/join_stream.rs
@@ -58,9 +58,9 @@ where
 /// use futures::stream::{self, StreamExt};
 /// use futures::future::ready;
 ///
-/// let a = &mut stream::once(ready(1u8));
-/// let b = &mut stream::once(ready(2u8));
-/// let c = &mut stream::once(ready(3u8));
+/// let a = stream::once(ready(1u8));
+/// let b = stream::once(ready(2u8));
+/// let c = stream::once(ready(3u8));
 ///
 /// let mut s = join!(a, b, c);
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 #![cfg_attr(test, deny(warnings))]
 
 mod join;
+mod join_stream;
 mod maybe_done;
 mod poll_fn;
 mod ready;
@@ -28,6 +29,7 @@ mod select;
 mod try_join;
 mod try_select;
 
+pub use join_stream::JoinStream;
 pub use maybe_done::MaybeDone;
 
 /// Helper re-exports for use in macros.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //! # Examples
 //!
 //! ```
-//! #![feature(async_await)]
 //! # futures::executor::block_on(async {
 //! use async_macros::join;
 //! use futures::future;


### PR DESCRIPTION
Depends on #1 to land first. Adds a new `stream_join` macro that can join multiple streams into a single stream:

```rust
let a = stream::once(1u8);
let b = stream::once(2u8);
let c = stream::once(3u8);

let mut s = join!(a, b, c);

assert_eq!(s.next().await, Some(1u8));
assert_eq!(s.next().await, Some(2u8));
assert_eq!(s.next().await, Some(3u8));
assert_eq!(s.next().await, None);
```

Thanks!